### PR TITLE
Remove 5th "Enter" key press to prevent opening chat bar

### DIFF
--- a/SINGLE_SPOT_AUTOMATED/Bot.au3
+++ b/SINGLE_SPOT_AUTOMATED/Bot.au3
@@ -81,8 +81,6 @@ Func LoginToUO($wh)
 		Sleep(5000)
 		Send("{ENTER}")
 		Sleep(5000)
-		Send("{ENTER}")
-		Sleep(5000)
 EndFunc
 
 Func GetTZOffset()


### PR DESCRIPTION
For users which open chat by pressing Enter first, the 5th "Enter" key press brings up the chat bar, resulting in the bot being unable to successfully logout.